### PR TITLE
Ac possibly useful tsconfig edit

### DIFF
--- a/src/lib/web-components/site-header/v0.1.1.js
+++ b/src/lib/web-components/site-header/v0.1.1.js
@@ -677,13 +677,24 @@ constructor() {
 
 // CONNECTED CALLBACK
 connectedCallback() {
-		// append the template content to the shadow DOM
-		this.shadowRoot?.appendChild(this.template.content.cloneNode(true))
+	// append the template content to the shadow DOM
+	this.shadowRoot?.appendChild(this.template.content.cloneNode(true))
 
-		// define refs elements
-		this.refs = ComponentUtils.getRefs(this.c, this);
+	// define refs elements
+	this.refs = ComponentUtils.getRefs(this.c, this);
 
-		if (this.dataJsonUrl) this.fetchData();
+	// the getRefs() method does not produce a direct reference to the menu-header links, so get them this way
+	this.menuHeadingLinks = this.shadowRoot?.querySelectorAll(".menu-heading-link");
+	
+	// add event listeners
+	this.menuHeadingLinks?.forEach((link) => {link.addEventListener("click", (e) => {this.refs["hamburger-toggle"].click()})});
+	
+	if (this.dataJsonUrl) this.fetchData();
+}
+
+// DISCONNECTED CALLBACK
+disconnectedCallback() {
+	this.menuHeadingLinks?.forEach((link) => {link.removeEventListener("click", (e) => {this.refs["hamburger-toggle"].click()})});
 }
 
 // ATTRIBUTE CHANGED CALLBACK

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,8 @@
 {
 	"extends": "./.svelte-kit/tsconfig.json",
 	"compilerOptions": {
+		"target": "ES2015",
+		"lib": ["dom", "es2015"],
 		"allowJs": true,
 		"checkJs": true,
 		"esModuleInterop": true,


### PR DESCRIPTION
Untangling my previous efforts to push when I didn't have permission was going to be more involved than copying my changes into a fresh clone.  I think I did this exactly according to my usual procedure, which is to change the package.json line setting the Node version from v18.x to "^20" and then install, but there are sometimes little behavioral variations from installation to installation.

This time, the expression defining the "ids" constant in the following lines...

// IDS
get ids() {
 const ids = [...`${this.styles}${this.els}`.matchAll(/id="([^"]+)"/g)].map((m) => m[1]);
 return ids;
}

...was showing a red linting error with the following message...

Type 'IterableIterator<RegExpExecArray>' can only be iterated through when using the '--downlevelIteration' flag or with a '--target' of 'es2015' or higher.

I consulted ChatGPT, and it told me to add a couple of lines to the tsconfig.json file.  These changes fixed the linting error, but given that this was an oddball error to begin with, you might determine upon review that the config changes are not necessary, or that a different change is in order.